### PR TITLE
wordpress : oauth 인증할때, blog를 설정하지 않을 때, 에러발생

### DIFF
--- a/routes/wordpress.js
+++ b/routes/wordpress.js
@@ -35,11 +35,20 @@ passport.use(new WordpressStrategy({
 //        console.log("accessToken:" + accessToken);
 //        console.log("refreshToken:" + refreshToken);
         console.log("profile:"+JSON.stringify(profile));
+        var providerId;
+        //if user didn't set blog for oauth, token_site_id set to false
+        if (profile._json.token_site_id != false) {
+            providerId = profile._json.token_site_id;
+        }
+        else {
+            providerId = profile._json.primary_blog;
+        }
+
         var provider = {
             "providerName":profile.provider,
             "accessToken":accessToken,
             "refreshToken":refreshToken,
-            "providerId":profile._json.token_site_id, //it is not user id
+            "providerId":providerId, //it is not user id
             "displayName":profile.displayName
         };
 
@@ -142,7 +151,13 @@ router.get('/bot_bloglist', function (req, res) {
         res.redirect("/#/signin");
         return;
     }
-
+    if (req.query.providerId == false) {
+        var errorMsg = 'User:'+user_id+' didnot have blog!';
+        console.log(errorMsg);
+        res.send(errorMsg);
+        res.redirect("/#/signin");
+        return;
+    }
     var p = userdb.findProviderId(user_id, req.query.providerid);
 
     var api_url = API_WORDPRESS_COM+"/sites/"+p.providerId;


### PR DESCRIPTION
wordpress : oauth 인증할때, blog를 설정하지 않을 때, 에러발
생
oauth 인증할때, blog를 설정하지 않을때, token_site_id가 false가 된다. 그 경우에는 primary_blog를 providerId로 사용한다.
