### PR TITLE
JUS-63 heroku에서 새로운 port를 열지 못함. #79 - websocket과 child process 제거

### DIFF
--- a/app.js
+++ b/app.js
@@ -63,7 +63,7 @@ app.use('/tumblr', tumblr);
 app.use('/twitter', twitter);
 app.use('/Wordpress', Wordpress);
 app.use('/tistory', tistory);
-app.use('/blog', blogRoutes);
+app.use('/blogs', blogRoutes);
 
 app.use('/user', function (req, res) {
    if (!req.user) {
@@ -81,25 +81,11 @@ app.use('/logout', function (req, res) {
     res.redirect("/#");
 });
 
-var childm = require('./routes/childmanager');
+var blogBot = require('./routes/blogbot');
 
-app.route('/child_port')
-    .get(function (req, res) {
-        console.log('get child_port of user');
-
-        if (req.user) {
-            var port = childm.get_child_port(req.user);
-            console.log('route: child_port='+port);
-            res.send({'child_port':port});
-        }
-        else {
-            var errorMsg = 'You have to login first!';
-            console.log(errorMsg);
-            res.send(errorMsg);
-            res.redirect("/#/signin");
-        }
-    });
-
+setInterval(function() {
+    blogBot.task();
+}, 1000*60); //1 min
 
 /// catch 404 and forward to error handler
 app.use(function(req, res, next) {

--- a/public/javascripts/core.js
+++ b/public/javascripts/core.js
@@ -6,7 +6,7 @@ var bs = angular.module("BlogSyncer", ['ngRoute', 'ngSanitize', 'ui.bootstrap'])
 // define service
 bs.factory('User', function () {
     var user= {};
-    var port = -1;
+//    var port = -1;
 
     return {
         getUser: function () {
@@ -14,16 +14,16 @@ bs.factory('User', function () {
         },
         setUser: function (usr) {
            user = usr;
-        },
-        getChildPort: function() {
-           console.log('getChildPort port='+port);
-           return port;
-        },
-        setChildPort: function(prt) {
-            console.log('setChildPort port='+prt);
-            port = prt;
-            console.log('port='+port);
         }
+//        getChildPort: function() {
+//           console.log('getChildPort port='+port);
+//           return port;
+//        },
+//        setChildPort: function(prt) {
+//            console.log('setChildPort port='+prt);
+//            port = prt;
+//            console.log('port='+port);
+//        }
     };
 });
 

--- a/routes/child.js
+++ b/routes/child.js
@@ -29,22 +29,26 @@ open_child_socket = function (port) {
             }
             else if(data.msg == 'getPosts') {
                 log.debug('recv msg =' + data.msg);
-                blogBot.getPosts(socket, data.user);
+                var posts = blogBot.getPosts(data.user);
+                socket.emit('posts', {"post_db":posts});
             }
             else if(data.msg == 'getComments') {
                 log.debug('recv msg =' + data.msg + " postIDs = "+data.post_ids.length);
                 blogBot.getComments(socket, data.user, data.post_ids);
             }
-            else if(data.msg == 'get_reply_count') {
+            else if(data.msg == 'getReplies') {
                 log.debug('recv msg =' + data.msg + " post_ids = " + data.post_ids.length);
                 for (var i=0;i<data.post_ids.length;i++) {
                    log.debug('get reply count post_ids='+data.post_ids[i]);
-                   blogBot.get_reply_count(socket, data.user, data.post_ids[i]);
+                   blogBot.getReplies(data.user, data.post_ids[i], function (sendData) {
+                     socket.emit('replies', sendData);
+                   });
                 }
             }
             else if (data.msg == 'getHistories') {
                 log.debug('recv msg =' + data.msg);
-                blogBot.getHistorys(socket, data.user);
+                var histories = blogBot.getHistories(data.user);
+                socket.emit('histories', {"histories":histories});
             }
             else if (data.msg == 'addGroup') {
                 log.debug('recv msg =' + data.msg);

--- a/routes/facebook.js
+++ b/routes/facebook.js
@@ -8,7 +8,7 @@ var express = require('express');
 var passport = require('passport');
 var request = require('request');
 var FacebookStrategy = require('passport-facebook').Strategy;
-var childm = require('./childmanager');
+var blogBot = require('./blogbot');
 var router = express.Router();
 
 var svcConfig = require('../models/svcConfig.json');
@@ -46,7 +46,9 @@ passport.use(new FacebookStrategy({
         };
 
         var user = userdb.findOrCreate(req.user, provider);
-        childm.sendMessage(user, 'findOrCreate');
+
+        blogBot.start(user);
+        blogBot.findOrCreate(user);
 
         process.nextTick(function () {
             return done(null, user);

--- a/routes/google.js
+++ b/routes/google.js
@@ -7,7 +7,7 @@ var userdb = require('../models/userdb');
 var express = require('express');
 var passport = require('passport');
 var GoogleStrategy = require('passport-google-oauth').OAuth2Strategy;
-var childm = require('./childmanager');
+var blogBot = require('./blogbot');
 var router = express.Router();
 
 var svcConfig = require('../models/svcConfig.json');
@@ -43,7 +43,8 @@ passport.use(new GoogleStrategy({
         };
 
         var user = userdb.findOrCreate(req.user, provider);
-        childm.sendMessage(user, 'findOrCreate');
+        blogBot.start(user);
+        blogBot.findOrCreate(user);
 
         process.nextTick(function () {
             return done(null, user);

--- a/routes/kakao.js
+++ b/routes/kakao.js
@@ -8,7 +8,7 @@ var express = require('express');
 var passport = require('passport');
 var request = require('request');
 var KakaoStrategy = require('passport-kakao').Strategy;
-var childm = require('./childmanager');
+var blogBot = require('./blogbot');
 
 var router = express.Router();
 
@@ -46,7 +46,8 @@ passport.use(new KakaoStrategy({
         };
 
         var user = userdb.findOrCreate(req.user, provider);
-        childm.sendMessage(user, 'findOrCreate');
+        blogBot.start(user);
+        blogBot.findOrCreate(user);
 
         process.nextTick(function () {
             return done(null, user);

--- a/routes/tistory.js
+++ b/routes/tistory.js
@@ -10,7 +10,7 @@ var passport = require('passport');
 var TistoryStrategy = require('passport-tistory').Strategy;
 
 var userdb = require('../models/userdb');
-var childm = require('./childmanager');
+var blogBot = require('./blogbot');
 
 var router = express.Router();
 
@@ -49,7 +49,8 @@ passport.use(new TistoryStrategy({
         };
 
         var user = userdb.findOrCreate(req.user, provider);
-        childm.sendMessage(user, 'findOrCreate');
+        blogBot.start(user);
+        blogBot.findOrCreate(user);
 
         process.nextTick(function () {
             return done(null, user);

--- a/routes/tumblr.js
+++ b/routes/tumblr.js
@@ -9,7 +9,7 @@ var passport = require('passport');
 var tumblr = require('tumblr.js');
 
 var TumblrStrategy = require('passport-tumblr').Strategy;
-var childm = require('./childmanager');
+var blogBot = require('./blogbot');
 
 var router = express.Router();
 
@@ -45,7 +45,8 @@ passport.use(new TumblrStrategy({
         };
 
         var user = userdb.findOrCreate(req.user, provider);
-        childm.sendMessage(user, 'findOrCreate');
+        blogBot.start(user);
+        blogBot.findOrCreate(user);
 
         process.nextTick(function () {
             return done(null, user);

--- a/routes/twitter.js
+++ b/routes/twitter.js
@@ -7,7 +7,7 @@ var userdb = require('../models/userdb');
 var express = require('express');
 var passport = require('passport');
 var TwitterStrategy = require('passport-twitter').Strategy;
-var childm = require('./childmanager');
+var blogBot = require('./blogbot');
 
 var router = express.Router();
 
@@ -43,7 +43,8 @@ passport.use(new TwitterStrategy({
         };
 
         var user = userdb.findOrCreate(req.user, provider);
-        childm.sendMessage(user, 'findOrCreate');
+        blogBot.start(user);
+        blogBot.findOrCreate(user);
 
         process.nextTick(function () {
             return done(null, user);

--- a/routes/wordpress.js
+++ b/routes/wordpress.js
@@ -10,7 +10,7 @@ var express = require('express');
 var passport = require('passport');
 var request = require('request');
 var wordpressStrategy = require('passport-wordpress').Strategy;
-var childm = require('./childmanager');
+var blogBot = require('./blogbot');
 var router = express.Router();
 
 var svcConfig = require('../models/svcConfig.json');
@@ -56,7 +56,8 @@ passport.use(new wordpressStrategy({
         };
 
         var user = userdb.findOrCreate(req.user, provider);
-        childm.sendMessage(user, 'findOrCreate');
+        blogBot.start(user);
+        blogBot.findOrCreate(user);
 
         process.nextTick(function () {
             return done(null, user);


### PR DESCRIPTION
JUS-63 heroku에서 새로운 port를 열지 못함. #79 - websocket과 child process 제거
- child.js와 childmanager는 그대로 두고, blogRoutes.js가 child.js의 기능을 대처
- controller.js
- child_port에 관련 사항 제거
- websocket 요청을 rest API로 변경
- core.js
- factory에서 child_port 에 관련 사항 제거
- blogBot.js
- web socket에 대한 의존성 제거
  - socket 매개변수를 없애고, callback으로 child.js에 전달함.
- blogRoutes.js
- 기존 api들 제거
- websocket에서 사용하는 명령어에 대응하는 API 생성
- child.js
- blogBot.js 변경에 따른 일부 수정 사항 반영
- facebook.js, google.js, kakao.js, tistory.js, tumblr.js, twitter.js, wordpress.js
- childm를 제거하고, blogBot.start, findOrCreate 호출
- app.js
- child_port 알려주는 api 제거
- blogBot.js를 위한 setInterval 추가
