### PR TITLE
Fixed #157 JUS-108 _cbSendPostToBlogs에서 user._id가 undefined인 경우.

### DIFF
--- a/routes/blogbot.js
+++ b/routes/blogbot.js
@@ -893,7 +893,7 @@ BlogBot._requestGetBlogList = function(user, providerName, providerId, callback)
 
         hasError = _checkError(err, response, body);
         if (hasError) {
-            callback(hasError);
+            callback(user);
             return;
         }
 
@@ -934,7 +934,7 @@ BlogBot._requestGetPostCount = function(user, providerName, blogId, callback) {
 
         hasError= _checkError(err, response, body);
         if (hasError) {
-            callback(hasError);
+            callback(user);
             return;
         }
 
@@ -996,7 +996,7 @@ BlogBot._requestGetPosts = function(user, providerName, blogId, options, callbac
 
         hasError= _checkError(err, response, body);
         if (hasError) {
-            callback(hasError);
+            callback(user);
             return;
         }
 
@@ -1171,7 +1171,7 @@ BlogBot._requestPostContent = function (user, post, providerName, blogId, callba
 
         hasError = _checkError(err, response, body);
         if (hasError) {
-            callback(hasError);
+            callback(user);
             return;
         }
 


### PR DESCRIPTION
Fixed #157 JUS-108 _cbSendPostToBlogs에서 user._id가 undefined인 경우.

*blogbot.js
 _requestGetBlogList, _requestGetPostCount, _requestGetPosts, _requestPostContent 에서 _checkError가 발생할때 msg인 hasError를 던지면 user 정보를 제대로 던지지 못하여 log meta가 제대로 못 던지는 문제가 있음.
 hasError 대신에 user정보를 전달하는 걸로 변경함.