### PR TITLE
Fixed #190 JUS-128 로그인 후에, 다른 provider 계정을 추가하는 경우 기존 로그인한 블로그가 디비에 한개더 생기는 문제. 

### DIFF
--- a/routes/blogbot.js
+++ b/routes/blogbot.js
@@ -625,7 +625,7 @@ BlogBot._cbAddBlogsToDb = function (user, recvBlogs) {
     site = blogDb.findSiteByProvider(provider.providerName, provider.providerId);
     if (site) {
         for (i=0; i<blogs.length; i+=1) {
-            blog = blogDb.findBlogFromSite(site, blogs[i].blog_id);
+            blog = blogDb.findBlogFromSite(site, blogs[i].blog_id.toString());
             if (!blog) {
                 site.blogs.push(blogs[i]);
                 BlogBot._requestGetPostCount(user, site.provider.providerName, blogs[i].blog_id,


### PR DESCRIPTION
blogId를 string으로 비교하기위해서, findBlogFromSite에 전달하는 값을 string으로 변경함.