### PR TITLE
Fixed #132 JUS-94 Twitter 글 목록 가져올 때 중복되는 부분 제거

### DIFF
--- a/controllers/blogbot.js
+++ b/controllers/blogbot.js
@@ -171,7 +171,7 @@ BlogBot._cbPushPostsToBlogs = function(user, rcvPosts) {
 //TODO: if post count over max it need to extra update - aleckim
     for(i=0; i<rcvPosts.posts.length;i+=1) {
         newPost = rcvPosts.posts[i];
-        if (postDb.findPostByPostIdOfBlog(rcvPosts.provider_name, rcvPosts.blog_id, newPost.id.toString())) {
+        if (postDb.isPostByPostIdOfBlog(rcvPosts.provider_name, rcvPosts.blog_id, newPost.id.toString())) {
             log.debug("This post was already saved - provider=" +
                     rcvPosts.provider_name + " blog=" + rcvPosts.blog_id + " post=" + newPost.id, meta);
             continue;
@@ -834,22 +834,30 @@ BlogBot._cbAddPostsToDb = function(user, rcvPosts) {
 
     //TODO: change from title to id
     for (i=0; i<rcvPosts.posts.length; i+=1) {
+        var rcvPost = rcvPosts.posts[i];
 
-        BlogBot._makeTitle(rcvPosts.posts[i]);
+        //check there is post
+        if (postDb.isPostByPostIdOfBlog(rcvPosts.provider_name, rcvPosts.blog_id, rcvPost.id.toString())) {
+            log.notice("This post was already saved - provider=" + rcvPosts.provider_name + " blog=" +
+                    rcvPosts.blog_id + " post=" + rcvPost.id, meta);
+            continue;
+        }
+
+        BlogBot._makeTitle(rcvPost);
 
         //log.debug(" " + rcvPosts.posts[i], meta);
         //if there is same title in postdb, add new in post object what has same title.
-        if (rcvPosts.posts[i].title) {
-            post = postDb.findPostByTitle(rcvPosts.posts[i].title);
+        if (rcvPost.title) {
+            post = postDb.findPostByTitle(rcvPost.title);
 
             //log.debug(rcvPosts.provider_name + rcvPosts.blog_id + rcvPosts.posts[i], meta);
             if (post) {
-                postDb.addPostInfo(post, rcvPosts.provider_name, rcvPosts.blog_id, rcvPosts.posts[i]);
+                postDb.addPostInfo(post, rcvPosts.provider_name, rcvPosts.blog_id, rcvPost);
                 continue;
             }
         }
 
-        postDb.addPost(rcvPosts.provider_name, rcvPosts.blog_id, rcvPosts.posts[i]);
+        postDb.addPost(rcvPosts.provider_name, rcvPosts.blog_id, rcvPost);
     }
 
     postDb.save(function (err) {

--- a/models/postdb.js
+++ b/models/postdb.js
@@ -185,7 +185,7 @@ postSchema.methods.findPostByTitle = function(title) {
  * @param {string} postId
  * @returns {boolean}
  */
-postSchema.methods.findPostByPostIdOfBlog = function(providerName, blogId, postId) {
+postSchema.methods.isPostByPostIdOfBlog = function(providerName, blogId, postId) {
     "use strict";
     var foundIt = false;
     var i;
@@ -194,7 +194,7 @@ postSchema.methods.findPostByPostIdOfBlog = function(providerName, blogId, postI
     var meta = {};
 
     meta.cName = "postSchema";
-    meta.fName = "findPostByPostIdOfBlog";
+    meta.fName = "isPostByPostIdOfBlog";
     meta.providerName = providerName;
     meta.blogId = blogId;
     meta.postId = postId;

--- a/test/test_postdb.js
+++ b/test/test_postdb.js
@@ -57,7 +57,7 @@ describe('postDb', function () {
         });
         it('find post by post id of blog', function () {
             var found = false;
-            found = postDb.findPostByPostIdOfBlog(testPostInfo.infos[0].provider_name,
+            found = postDb.isPostByPostIdOfBlog(testPostInfo.infos[0].provider_name,
                         testPostInfo.infos[0].blog_id, testPostInfo.infos[0].post_id);
             assert.equal(found, true, "Fail to find post by post id of blog");
         });


### PR DESCRIPTION
Fixed #132 JUS-94 Twitter 글 목록 가져올 때 중복되는 부분 제거

* rename findPostByPostIdOfBlog to isPostByPostIdOfBlog
* check post is already stored to db in _cbAddPostsToDb.
  post가 이미 디비에 있는지 확인.