### PR TITLE
Fixed #215 tumblr에 반응(notes, replies)정보 가지고 오기.

### DIFF
--- a/routes/tumblr.js
+++ b/routes/tumblr.js
@@ -362,7 +362,12 @@ function _pushPostsFromTumblr(posts, raw_posts, is_body, after) {
                 log.debug('Fail to get type ' + raw_post.type);
                 break;
         }
+
         send_post.replies = [];
+        if (raw_post.note_count !== undefined) {
+            send_post.replies.push({"notes": raw_post.note_count});
+        }
+
         posts.push(send_post);
     }
 }
@@ -450,7 +455,7 @@ router.get('/bot_posts/:blog_id/:post_id', function (req, res) {
             token_secret: provider.tokenSecret
         });
 
-        var options = {id: post_id};
+        var options = {id: post_id, reblog_info: true, notes_info: true};
 
         client.posts(blog_id, options, function (error, response) {
             var send_data = {};


### PR DESCRIPTION
Fixed #215 tumblr에 반응(notes, replies)정보 가지고 오기.

단일 post가지고 올때, reblog_info와 notes_info를 true로 전달.
notes의 length와 note_count 수가 다른데, note_count가 맞는 것오고, note type 중에서 like, reblog만 전달해야 함.