### PR TITLE
Fixed #264 로그인이 되지 않은 상태일 때 Login 페이지로 이동 시에 pullSitesFromServer에서 잘못…

### DIFF
--- a/controllers/userManager.js
+++ b/controllers/userManager.js
@@ -189,7 +189,6 @@ UserMgr._getUserId = function (req, res) {
         log.debug(errorMsg, meta);
         if (res) {
             res.send(errorMsg);
-            res.redirect("/#/signin");
         }
     }
     return userId;

--- a/routes/blogRoutes.js
+++ b/routes/blogRoutes.js
@@ -21,7 +21,6 @@ function _getUser(req, res) {
         var errorMsg = 'You have to login first!';
         log.error(errorMsg);
         res.status(401).send(errorMsg); //401 Unauthorized
-        res.redirect("/#/signin");
         return;
     }
 


### PR DESCRIPTION
…된 data가 들어오는 문제

* sites를 요청하면 req.user가 없는 경우 401 에러와 함께 로그인 페이지로 redirect 시키고 있음
* 로그인 페이지의 html을 data에 전달하여 발생한 문제임
* 서버에서 직접 페이지 이동시키는 코드 제거(필요 시에 클라이언트에서 해야 함)