### PR TITLE
Fixed #316 새로운 글 sync중에 에러 발생시에 복구

### DIFF
--- a/controllers/blogConvert.js
+++ b/controllers/blogConvert.js
@@ -297,7 +297,7 @@ var blogConvert = {
         }
 
         if (!urls.length) {
-            content = blogConvert.makeLimitString(maxLen, content, hashTags.toString());
+            content = blogConvert.makeLimitString(maxLen, content, hashTags.join(' '));
             return callBack(content);
         }
 
@@ -317,13 +317,8 @@ var blogConvert = {
                 log.error('Fail to get shortenUrl');
                 return callBack(err);
             }
-            var hashTagString = '';
-            if (!blogConvert.getHashTags(content)) {
-                //have to add hashTags
-                hashTagString = hashTags.toString();
-            }
 
-            content = blogConvert.makeLimitString(maxLen, content, hashTagString, shortenUrls);
+            content = blogConvert.makeLimitString(maxLen, content, hashTags.join(' '), shortenUrls);
             return callBack(content);
         });
     },
@@ -404,6 +399,13 @@ var blogConvert = {
         if (content.length) {
             cutLen += content.length;
         }
+
+        var hashTags = blogConvert.getHashTags(content);
+        if (hashTags && hashTags.length) {
+            log.debug('This content has been hashTags');
+            tagString = '';
+        }
+
         if (tagString && tagString.length) {
             cutLen += 1 + tagString.length;
         }
@@ -474,6 +476,11 @@ var blogConvert = {
      */
     getHashTags: function(content) {
         var hashTags = [];
+
+        if (!content || !content.replace) {
+            log.error((new Error('content is not String')).stack);
+            return hashTags;
+        }
 
         content.replace(/(#|＃)([a-z0-9_\u00c0-\u00d6\u00d8-\u00f6\u00f8-\u00ff\u0100-\u024f\u0253-\u0254\u0256-\u0257\u0300-\u036f\u1e00-\u1eff\u0400-\u04ff\u0500-\u0527\u2de0-\u2dff\ua640-\ua69f\u0591-\u05bf\u05c1-\u05c2\u05c4-\u05c5\u05d0-\u05ea\u05f0-\u05f4\ufb12-\ufb28\ufb2a-\ufb36\ufb38-\ufb3c\ufb40-\ufb41\ufb43-\ufb44\ufb46-\ufb4f\u0610-\u061a\u0620-\u065f\u066e-\u06d3\u06d5-\u06dc\u06de-\u06e8\u06ea-\u06ef\u06fa-\u06fc\u0750-\u077f\u08a2-\u08ac\u08e4-\u08fe\ufb50-\ufbb1\ufbd3-\ufd3d\ufd50-\ufd8f\ufd92-\ufdc7\ufdf0-\ufdfb\ufe70-\ufe74\ufe76-\ufefc\u200c-\u200c\u0e01-\u0e3a\u0e40-\u0e4e\u1100-\u11ff\u3130-\u3185\ua960-\ua97f\uac00-\ud7af\ud7b0-\ud7ff\uffa1-\uffdc\u30a1-\u30fa\u30fc-\u30fe\uff66-\uff9f\uff10-\uff19\uff21-\uff3a\uff41-\uff5a\u3041-\u3096\u3099-\u309e\u3400-\u4dbf\u4e00-\u9fff\u20000-\u2a6df\u2a700-\u2b73f\u2b740-\u2b81f\u2f800-\u2fa1f]*[a-z_\u00c0-\u00d6\u00d8-\u00f6\u00f8-\u00ff\u0100-\u024f\u0253-\u0254\u0256-\u0257\u0300-\u036f\u1e00-\u1eff\u0400-\u04ff\u0500-\u0527\u2de0-\u2dff\ua640-\ua69f\u0591-\u05bf\u05c1-\u05c2\u05c4-\u05c5\u05d0-\u05ea\u05f0-\u05f4\ufb12-\ufb28\ufb2a-\ufb36\ufb38-\ufb3c\ufb40-\ufb41\ufb43-\ufb44\ufb46-\ufb4f\u0610-\u061a\u0620-\u065f\u066e-\u06d3\u06d5-\u06dc\u06de-\u06e8\u06ea-\u06ef\u06fa-\u06fc\u0750-\u077f\u08a2-\u08ac\u08e4-\u08fe\ufb50-\ufbb1\ufbd3-\ufd3d\ufd50-\ufd8f\ufd92-\ufdc7\ufdf0-\ufdfb\ufe70-\ufe74\ufe76-\ufefc\u200c-\u200c\u0e01-\u0e3a\u0e40-\u0e4e\u1100-\u11ff\u3130-\u3185\ua960-\ua97f\uac00-\ud7af\ud7b0-\ud7ff\uffa1-\uffdc\u30a1-\u30fa\u30fc-\u30fe\uff66-\uff9f\uff10-\uff19\uff21-\uff3a\uff41-\uff5a\u3041-\u3096\u3099-\u309e\u3400-\u4dbf\u4e00-\u9fff\u20000-\u2a6df\u2a700-\u2b73f\u2b740-\u2b81f\u2f800-\u2fa1f][a-z0-9_\u00c0-\u00d6\u00d8-\u00f6\u00f8-\u00ff\u0100-\u024f\u0253-\u0254\u0256-\u0257\u0300-\u036f\u1e00-\u1eff\u0400-\u04ff\u0500-\u0527\u2de0-\u2dff\ua640-\ua69f\u0591-\u05bf\u05c1-\u05c2\u05c4-\u05c5\u05d0-\u05ea\u05f0-\u05f4\ufb12-\ufb28\ufb2a-\ufb36\ufb38-\ufb3c\ufb40-\ufb41\ufb43-\ufb44\ufb46-\ufb4f\u0610-\u061a\u0620-\u065f\u066e-\u06d3\u06d5-\u06dc\u06de-\u06e8\u06ea-\u06ef\u06fa-\u06fc\u0750-\u077f\u08a2-\u08ac\u08e4-\u08fe\ufb50-\ufbb1\ufbd3-\ufd3d\ufd50-\ufd8f\ufd92-\ufdc7\ufdf0-\ufdfb\ufe70-\ufe74\ufe76-\ufefc\u200c-\u200c\u0e01-\u0e3a\u0e40-\u0e4e\u1100-\u11ff\u3130-\u3185\ua960-\ua97f\uac00-\ud7af\ud7b0-\ud7ff\uffa1-\uffdc\u30a1-\u30fa\u30fc-\u30fe\uff66-\uff9f\uff10-\uff19\uff21-\uff3a\uff41-\uff5a\u3041-\u3096\u3099-\u309e\u3400-\u4dbf\u4e00-\u9fff\u20000-\u2a6df\u2a700-\u2b73f\u2b740-\u2b81f\u2f800-\u2fa1f]*)/gi,
             function (m) {

--- a/models/historydb.js
+++ b/models/historydb.js
@@ -10,11 +10,19 @@ historySchema = mongoose.Schema({
     histories: [{
         tryTime: Date,
         status: String,
+        title: String,
+        description: String,
         src: {
-            title: String, id: String, url: String
+            providerName: String,
+            blogId: String,
+            postId: String,
+            url: String
         },
         dst: {
-            id: String,  url: String
+            providerName: String,
+            blogId: String,
+            postId: String,
+            url: String
         }
     }]
 });

--- a/models/postdb.js
+++ b/models/postdb.js
@@ -87,7 +87,7 @@ postSchema.methods.getPostByPostIdOfBlog = function(providerName, blogId, postId
         }
     }
 
-    log.error('Fail to find providerName='+providerName+' blogId='+blogId+ ' post id=' + postId, meta);
+    log.silly('Fail to find providerName='+providerName+' blogId='+blogId+' post id='+postId, meta);
 };
 
 /**
@@ -286,6 +286,25 @@ postSchema.methods.addPost = function(providerName, blogId, newPost) {
 
     log.silly("Total=" + this.posts.length, meta);
     return this.posts[totalCount];
+};
+
+/**
+ *
+ * @param postInfo
+ * @param providerName
+ * @param blogId
+ */
+postSchema.methods.getInfoFromPostInfo = function(postInfo, providerName, blogId) {
+    for (var i=0; i<postInfo.infos.length; i+=1) {
+        var info = postInfo.infos[i];
+        if (info.provider_name === providerName && info.blog_id === blogId) {
+            return info;
+        }
+    }
+
+    log.verbose("Fail to get info");
+    log.verbose(postInfo);
+    log.verbose("providerName="+providerName+" blogId="+blogId);
 };
 
 module.exports = mongoose.model('Post', postSchema);

--- a/test/test_blogBot.js
+++ b/test/test_blogBot.js
@@ -6,17 +6,20 @@
 var assert  = require('assert');
 var bB = require('../controllers/blogBot');
 var tD = require('./test_data');
+var botFormat = require('../models/botFormat');
 if (!global.log) {
     global.log = require('winston');
 }
 
 var testUserId = 'xxxxx';
 
+var user = {
+    _id: testUserId,
+    providers: [tD.testProvider1, tD.testProvider2]
+};
+
 bB.users = [{
-    user: {
-        _id: testUserId,
-        providers: [tD.testProvider1, tD.testProvider2]
-    },
+    user: user,
     blogDb: {
         sites: [{
             provider: tD.testProvider1,
@@ -27,6 +30,40 @@ bB.users = [{
 
 
 describe('blogBot', function () {
+    describe('retry posting', function () {
+        var botRetry;
+
+        it('add retry queue', function () {
+            var userInfo = bB.users[0];
+
+            userInfo.retryDb = {};
+            userInfo.retryDb.queue = [];
+
+            var botPostList = new botFormat.BotPostList(tD.testProvider1.providerName, tD.testBlog1.blog_id);
+            var botTextPost = new botFormat.BotTextPost(tD.testTextPost1.id, tD.testTextPost1.content,
+                        tD.testTextPost1.modified, tD.testTextPost1.post_url, tD.testTextPost1.title,
+                        tD.testTextPost1.categories, tD.testTextPost1.tags, tD.testTextPost1.replies);
+            botPostList.posts.push(botTextPost);
+
+            var botPostList2 = new botFormat.BotPostList(tD.testProvider2.providerName, tD.testBlog2.blog_id);
+
+            botRetry = {srcBotPosts:botPostList, dstBotPosts:botPostList2};
+            bB._addRetryPosting(user, botRetry);
+
+            var retryDb = bB._findDbByUser(user, "retry");
+
+            assert.equal(retryDb.queue[0].srcBotPosts.posts[0].id, tD.testTextPost1.id, "Mismatch post id");
+        });
+        it('retry posting', function () {
+            var tmpBotRetry;
+            bB._retryPost = function (user, botRetry) {
+                tmpBotRetry = botRetry;
+            };
+            bB._retryPostings(user);
+
+            assert.equal(botRetry.srcBotPosts.posts[0].id, tmpBotRetry.srcBotPosts.posts[0].id, "Mismatch post id");
+        });
+    });
     describe('botTeaser', function () {
         it('get botTeaser', function (done) {
             this.timeout(4000);

--- a/test/test_blogConvert.js
+++ b/test/test_blogConvert.js
@@ -106,7 +106,7 @@ describe('blogConvert', function () {
         var MAX_PLAIN_TEXT_LENGTH = 140;
 
         it('make limit length string', function () {
-            var hashTagString = bC.convertTagToHashtag(tD.testPainTextPost1.tags).toString();
+            var hashTagString = bC.convertTagToHashtag(tD.testPainTextPost1.tags).join(' ');
             var str;
             var urls = [];
 
@@ -217,6 +217,9 @@ describe('blogConvert', function () {
 
             hashTags = bC.getHashTags(tD.testStringForHashTags3);
             assert.equal(hashTags.toString(), tD.testStringForHashTagsResult3, true, "Mismatch hashtags");
+
+            hashTags = bC.getHashTags(undefined);
+            assert.equal(Array.isArray(hashTags), true, true, "Mismatch hashtags");
         });
         it('link post to teaser text content', function (done) {
             this.timeout(5000);

--- a/test/test_data.js
+++ b/test/test_data.js
@@ -63,15 +63,15 @@ var testData = {
 
     testPainTextPost1: {
         id: '333',
-        content: '지난주 있었던 Y Combinator의 demo day 1에서 나온 수십개 startup중 소비자에게 어필할만한 몇개를 추려봤습니다. 빨래 픽업/배달 서비스 http://www.getcleanly.com 출퇴근 교통 솔루션. 출발지 목적지를 쓰면 미니밴이 와서 픽업. 가까운 미래에 구글 무인자동차와 이 서비스가 결합하여 버스나 택시 등 기존 수단을 대체할 것으로 보입니다. https://www.chariotsf.com 이제 더 이상 노트북이나 데스크톱을 살 필요가 없다? 클라우드 컴퓨터 https://paperspace.io 가방무게도 알수있고, 여행 기록도 볼수있으며, 가방과 멀어지면 경고도 보내주어 분실을 방지해주는 스마트 여행가방. 게다가 알루미늄 박스 가방에 비하면 저렴한 가격. http://bluesmart.com 컴퓨터 코딩을 배워 본다고 Udemy를 종종 사용했는데 그것과 유사한 서비스. 아쉬운 점은 이런 서비스 대부분이 영어로 강의를 하기때문에 비영어권 접근이 쉽지 않습니다. 20세기보다 영어가 더 절실해지는 상황.. https://courses.platzi.com 이제 요리한다고 불 앞에 서서 땀흘리고 기름냄새 맡을 일이 없습니다. 스마트 하게 세팅만 해주면 알아서 요리해주는 머신 https://cindercooks.com 이메일 내용을 파악해서 똑똑한 비서처럼 정리해준다는데.. 안써봐서 어느정도로 스마트한지는 모르겠습니다 http://www.slidemailapp.com/#tmhmdj:E4Og 자전거를 타고 가다가 뒤에 뭐가 있나 뒤돌아 보거나 거울을 보고 계시나요? 모르는 길을 갈때 스마트폰 지도앱 네비게이션을 중간중간 확인 하나요? 이 스마트 자전거는 물체가 근접하면 경고음을 내고 지도앱 내비게이션과 연동해서 운전손잡이에 방향 지시등이 들어 온답니다. 게다가 슬릭한 디자인. https://vanhawks.com 앞으로도 이런 자료를 보고 싶다면 odd things 페북 페이지에 가서 like! https://facebook.com/oddthingsLLC',
+        content: '지난주 있었던 Y Combinator의 demo day 1에서 나온 수십개 startup중 소비자에게 어필할만한 몇개를 추려봤습니다. 빨래 픽업/배달 서비스 http://www.getcleanly.com 출퇴근 교통 솔루션. 출발지 목적지를 쓰면 미니밴이 와서 픽업. 가까운 미래에 구글 무인자동차와 이 서비스가 결합하여 버스나 택시 등 기존 수단을 대체할 것으로 보입니다. https://www.chariotsf.com 이제 더 이상 노트북이나 데스크톱을 살 필요가 없다? 클라우드 컴퓨터 https://paperspace.io 가방무게도 알수있고, 여행 기록도 볼수있으며, 가방과 멀어지면 경고도 보내주어 분실을 방지해주는 스마트 여행가방. 게다가 알루미늄 박스 가방에 비하면 저렴한 가격. http://bluesmart.com 컴퓨터 코딩을 배워 본다고 Udemy를 종종 사용했는데 그것과 유사한 서비스. 아쉬운 점은 이런 서비스 대부분이 영어로 강의를 하기때문에 비영어권 접근이 쉽지 않습니다. 20세기보다 영어가 더 절실해지는 상황.. https://courses.platzi.com 이제 요리한다고 불 앞에 서서 땀흘리고 기름냄새 맡을 일이 없습니다. 스마트 하게 세팅만 해주면 알아서 요리해주는 머신 https://cindercooks.com 이메일 내용을 파악해서 똑똑한 비서처럼 정리해준다는데.. 안써봐서 어느정도로 스마트한지는 모르겠습니다 http://www.slidemailapp.com/tmhmdj:E4Og 자전거를 타고 가다가 뒤에 뭐가 있나 뒤돌아 보거나 거울을 보고 계시나요? 모르는 길을 갈때 스마트폰 지도앱 네비게이션을 중간중간 확인 하나요? 이 스마트 자전거는 물체가 근접하면 경고음을 내고 지도앱 내비게이션과 연동해서 운전손잡이에 방향 지시등이 들어 온답니다. 게다가 슬릭한 디자인. https://vanhawks.com 앞으로도 이런 자료를 보고 싶다면 odd things 페북 페이지에 가서 like! https://facebook.com/oddthingsLLC',
         modified: d,
         post_url: 'http://is.gd/N5CgDW',
         title: '',
         tags: ['oddthings', 'startup', '스타트업', 'ycombinator', '유용한정보', '유용한어플', '아이오티', 'ioT' ],
         replies: [{'notes': 99}]
     },
-    testPainTextLimitStringResult1: '지난주 있었던 Y Combinator의 demo day 1에서 나온 수십개 startup중 소비자에 #oddthings,#startup,#스타트업,#ycombinator,#유용한정보,#유용한어플,#아이오티,#ioT http://is.gd/N5CgDW',
-    testPainTextLimitStringResult2: '#oddthings,#startup,#스타트업,#ycombinator http://is.gd/N5CgDW',
+    testPainTextLimitStringResult1: '지난주 있었던 Y Combinator의 demo day 1에서 나온 수십개 startup중 소비자에 #oddthings #startup #스타트업 #ycombinator #유용한정보 #유용한어플 #아이오티 #ioT http://is.gd/N5CgDW',
+    testPainTextLimitStringResult2: '#oddthings #startup #스타트업 #ycombinator http://is.gd/N5CgDW',
     testLinkPost1: {
         id: '3333333',
         url: 'https://docs.angularjs.org/tutorial/step_02',

--- a/test/test_historydb.js
+++ b/test/test_historydb.js
@@ -11,8 +11,6 @@ if (!global.log) {
     global.log = require('winston');
 }
 
-var testHistory = tD.testHistory;
-
 describe('historyDb', function () {
     describe('Function', function () {
         var historyDb;
@@ -21,8 +19,8 @@ describe('historyDb', function () {
             assert.notEqual(typeof historyDb, "undefined", "Fail to create historyDb");
         });
         it('add historyDb', function () {
-            historyDb.histories.push(testHistory);
-            assert.equal(historyDb.histories[0].src.title, testHistory.src.title, "Fail to add historyDb");
+            historyDb.histories.push(tD.testHistory);
+            assert.equal(historyDb.histories[0].title, tD.testHistory.title, "Fail to add historyDb");
         });
     });
 });

--- a/test/test_postdb.js
+++ b/test/test_postdb.js
@@ -61,6 +61,13 @@ describe('postDb', function () {
             retPost = postDb.addPost("newProvider", "328422", newPost);
             assert.equal(retPost.title, newPost.title, "Fail to add post");
         });
+        it('get info from postInfo', function () {
+
+            var postInfo = postDb.findPostByTitle(testPostInfo.title);
+            var info = postDb.getInfoFromPostInfo(postInfo, testPostInfo.infos[0].provider_name,
+                        testPostInfo.infos[0].blog_id);
+            assert.equal(info.url, testPostInfo.infos[0].url, "Fail to match url");
+        });
     });
 });
 


### PR DESCRIPTION
_requestPostContent parameter로 retry에 필요한 정보를 모두 전달한다.
새로운 글이면, postInfo가 있는지 확인하고, 없으면 postInfo를 만든다.
group를 돌면서 postInfo의 infos array에 없는 blog에 posting한다.
에러가 발생하면, retryDb에 저장하고, 다음 task에 시도한다.
hashTags는 공백으로 분리된다.
post type이 photo인데 media url이 없는 경우에 대하여 예외처리함.

add retryDb to BlogBot.
add _retryPost(), _retryPostings(),_addRetryPosting() to BlogBot
check content to have hashtags in makeLimitString
update historySchema
add getInfoFromPostInfo() to postdb.js