### PR TITLE
Fixed #304 iPhone, iPad 에서 언어가 한국어,영어가 페이지 로딩할 때마다 변경됨.

### DIFF
--- a/public/javascripts/controller.js
+++ b/public/javascripts/controller.js
@@ -10,9 +10,6 @@ bs.controller('mainCtrl', function ($q, $scope, $http, $translate, Data, Type) {
 
     console.log('Start mainCtrl');
 
-    var lang = navigator.language.split("-"); //ko, ko-kr 둘 다 ko로 설정
-    $translate.use(lang[0]);
-
     if (!$scope.user._id) {
         $http.get('/user')
             .success(function (data) {

--- a/public/javascripts/core.js
+++ b/public/javascripts/core.js
@@ -124,7 +124,8 @@ bs.config(function ($translateProvider) {
         prefix: 'views/strings/',
         suffix: '.json'
     });
-    $translateProvider.preferredLanguage('en');
+    var lang = navigator.language.split("-"); //ko, ko-kr 둘 다 ko로 설정
+    $translateProvider.preferredLanguage(lang[0]);
 });
 
 


### PR DESCRIPTION
* 언어 설정을 mainCtrl 로딩 시점에서 $translateProvider에 언어별 String 설정할 때 하도록 시점 이동