### PR TITLE
Fixed #328 Facebook에서 tiwtter로 posting시에 'Could not authenticate you.…

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,6 @@
   ],
   "private": true,
   "scripts": {
-    "start": "node ./bin/www"
-  },
-  "scripts": {
     "test": "mocha",
     "start": "node ./bin/www"
   },
@@ -58,6 +55,7 @@
     "shorturl": "0.0.3",
     "socket.io": "~1.0.6",
     "tumblr.js": "~0.0.4",
+    "twitter": "^1.2.5",
     "winston": "~1.0.0"
   }
 }


### PR DESCRIPTION
…' 발생

blogBot.js
modify log level
ignore error in getAndPush - if return error in getAndPush, do not start retrypost
ignore error in task
When postStatus was 403, skip retry posting

twitter.js
when posting, use npm twitter for POST.
max length of status message set to 136 when POST.

package.json
add twitter