### PR TITLE
Fixed #337 구글의 blogger에 등록된 blog가 없을 경우 오류 발생하던 것을 수정

### DIFF
--- a/routes/google.js
+++ b/routes/google.js
@@ -157,19 +157,21 @@ router.get('/bot_bloglist', function (req, res) {
             }
 
             var botBlogList = new botFormat.BotBlogList(provider);
-            try {
-                var items = body.items;
-                log.debug("items length=" + items.length, meta);
+            if(body.items !== undefined) {
+                try {
+                    var items = body.items;
+                    log.debug("items length=" + items.length, meta);
 
-                for (var i = 0; i < items.length; i+=1) {
-                    var botBlog = new botFormat.BotBlog(items[i].id, items[i].name, items[i].url);
-                    botBlogList.blogs.push(botBlog);
+                    for (var i = 0; i < items.length; i += 1) {
+                        var botBlog = new botFormat.BotBlog(items[i].id, items[i].name, items[i].url);
+                        botBlogList.blogs.push(botBlog);
+                    }
                 }
-            }
-            catch(e) {
-                log.error(e, meta);
-                log.error(body, meta);
-                return res.status(500).send(e);
+                catch (e) {
+                    log.error(e, meta);
+                    log.error(body, meta);
+                    return res.status(500).send(e);
+                }
             }
 
             res.send(botBlogList);


### PR DESCRIPTION
##### 구글의 blogger에 blog가 없을 경우 body.items가 undefined 입니다.
아래와 같이 body.items를 확인하는 부분을 추가했습니다.
botBlogList는 생성자만 호출한 빈값이며, 빈값을 caller에게 반환합니다.

routes/google.js(159)
```javascript
var botBlogList = new botFormat.BotBlogList(provider);
try {
    var items = body.items;
```
                         ↓↓↓
```javascript
var botBlogList = new botFormat.BotBlogList(provider);
if(body.items !== undefined) {
    try {
        var items = body.items;
```