### PR TITLE
Fixed #347 tistory one blog

### DIFF
--- a/routes/tistory.js
+++ b/routes/tistory.js
@@ -179,7 +179,12 @@ router.get('/bot_bloglist', function (req, res) {
             var botBlogList = new botFormat.BotBlogList(provider);
 
             try {
-                var item = JSON.parse(body).tistory.item;
+                var item = [];
+                if(typeof JSON.parse(body).tistory.item !== 'array') {
+                    item[0] = JSON.parse(body).tistory.item;
+                } else {
+                    item = JSON.parse(body).tistory.item;
+                }
                 log.debug('item length=' + item.length, meta);
 
                 for (var i = 0; i < item.length; i+=1) {


### PR DESCRIPTION
티스토리 블로그가 하나밖에 없을 경우 반환값이 배열이 아닌 Object를 반환한다.

array와 object를 구별하여 처리