### PR TITLE
Fixed #363 tistory의 category list 오류를 error에서 warn으로 변경

### DIFF
--- a/routes/tistory.js
+++ b/routes/tistory.js
@@ -657,7 +657,7 @@ function _getCategoryIds(target_api_url, accessToken, get, cb) {
         catch (e) {
             e.statusCode = 500;
             e.routerMessage = "Fail to get category info";
-            log.error(e);
+            log.warn(e);
             category = [];
             cb(e);
         }


### PR DESCRIPTION
"Cannot read property 'categories' of undefined" 에러 발생
